### PR TITLE
Add up down selection change in the launcher using tab and shift tab

### DIFF
--- a/js/components/Launcher.js
+++ b/js/components/Launcher.js
@@ -89,8 +89,10 @@ class Launcher extends Component {
       // Change selection
       case 'ArrowUp':
       case 'ArrowDown':
+      case 'Tab':
       event.preventDefault();
-      const delta = event.key === 'ArrowDown' ? 1 : -1;
+      const moveDown = event.key === 'ArrowDown' || event.key === 'Tab' && !event.getModifierState('Shift');
+      const delta = moveDown ? 1 : -1;
       if (this.state.suggestions.length) {
         let nextSelectedIndex =
           (this.state.selectedIndex + delta + this.state.suggestions.length)


### PR DESCRIPTION
Add functionality where you can move the selection down with **Tab** and up with **Shift + Tab** in the launcher input. Still works with the arrow keys as well.